### PR TITLE
Update changelog, README, and configuration files for k3d and Cilium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Server-side apply configurations for better resource management
 - Subnet consistency across different CNI configurations
 - Image version alignment for reliable deployments
+- k3d cluster creation failure due to smart quotes in cluster-cidr configuration
+- Connectivity test race condition where CNI policies weren't fully applied before testing
+- Test output verbosity - connectivity test now only checks for HTTP 200 status instead of printing full response
 
 ### Security
 

--- a/infrastructure/k3d/calico-config.yaml
+++ b/infrastructure/k3d/calico-config.yaml
@@ -4,15 +4,15 @@ metadata:
   name: calico
 servers: 1
 agents: 2
-image: rancher/k3s:v1.33.1-k3s1
-subnet: "172.28.0.0/16"
+image: rancher/k3s:v1.32.5-k3s1
+subnet: "10.42.0.0/16"
 ports:
   - port: 8080:80
     nodeFilters:
       - loadbalancer
-  # - port: 6443:6443
-  #   nodeFilters:
-  #     - loadbalancer
+  - port: 6443:6443
+    nodeFilters:
+      - loadbalancer
 options:
   k3s:
     extraArgs:
@@ -24,12 +24,12 @@ options:
         nodeFilters:
           - server:*
       # Calico specific settings
-      # - arg: --cluster-cidr="172.28.0.0/16"
-      #   nodeFilters:
-      #     - server:*
-      # - arg: --service-cidr=10.96.0.0/12
-      #   nodeFilters:
-      #     - server:*
+      - arg: --cluster-cidr=10.42.0.0/16
+        nodeFilters:
+          - server:*
+      - arg: --service-cidr=10.96.0.0/12
+        nodeFilters:
+          - server:*
       # Disable traefik
       - arg: --disable=traefik
         nodeFilters:

--- a/infrastructure/k3d/cilium-config.yaml
+++ b/infrastructure/k3d/cilium-config.yaml
@@ -5,7 +5,7 @@ metadata:
 servers: 1
 agents: 2
 image: rancher/k3s:v1.32.5-k3s1
-subnet: "172.28.0.0/16"
+subnet: "10.42.0.0/16"
 ports:
   - port: 8080:80
     nodeFilters:
@@ -39,9 +39,9 @@ options:
       - arg: --disable-kube-proxy
         nodeFilters:
           - server:*
-      - arg: --cluster-cidr="172.28.0.0/16"
+      - arg: --cluster-cidr=10.42.0.0/16
         nodeFilters:
           - server:*
-      - arg: --service-cidr="10.42.0.0/16"
+      - arg: --service-cidr=10.96.0.0/12
         nodeFilters:
           - server:*

--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@ set export := true
 set ignore-comments := true
 set quiet := true
 set dotenv-load := true
-set dotenv-filename := cluster.env
+set dotenv-filename := 'cluster.env'
 
 # Variables with defaults
 cluster_name := env_var_or_default("CLUSTER_NAME", "calico")
@@ -247,5 +247,10 @@ test-connectivity:
         kubectl create deployment nginx --image=nginx --replicas=2 || true; \
         kubectl wait --for=condition=available --timeout=60s deployment/nginx; \
         kubectl expose deployment nginx --port=80 --type=ClusterIP || true; \
-        kubectl run test-pod --image=busybox --rm -it --restart=Never -- wget -O- http://nginx; \
+        echo "Waiting for network policies to be applied..."; \
+        sleep 5; \
+        kubectl run test-pod --image=busybox --rm -it --restart=Never -- wget --spider -S http://nginx 2>&1 | grep "HTTP/" | grep "200"; \
+        kubectl delete svc/nginx; \
+        kubectl delete deployment/nginx; \
+        echo "Basic connectivity test completed."; \
     fi


### PR DESCRIPTION
- Document k3d cluster creation failure due to smart quotes in cluster-cidr configuration
- Address connectivity test race condition by adding a delay in justfile
- Update subnet and cluster-cidr values in calico and cilium configuration files